### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/link.php
+++ b/syntax/link.php
@@ -49,7 +49,7 @@ class syntax_plugin_bugzillaint_link extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Handle matches
 	 */
-	public function handle($match, $state, $pos, &$handler){
+	public function handle($match, $state, $pos, Doku_Handler $handler){
 		$matches = array();
 		
 		// found link
@@ -73,7 +73,7 @@ class syntax_plugin_bugzillaint_link extends DokuWiki_Syntax_Plugin {
 	 * @param array $data
 	 * @return boolean
 	 */
-	public function render($mode, &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		if ($mode != 'xhtml') return false;
 
 		// render link

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -49,7 +49,7 @@ class syntax_plugin_bugzillaint_list extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Handle matches
 	 */
-	public function handle($match, $state, $pos, &$handler){
+	public function handle($match, $state, $pos, Doku_Handler $handler){
 		$matches = array();
 
 		// found list
@@ -74,7 +74,7 @@ class syntax_plugin_bugzillaint_list extends DokuWiki_Syntax_Plugin {
 	 * @param array $data
 	 * @return boolean
 	 */
-	public function render($mode, &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		if ($mode != 'xhtml') return false;
 
 		// render list

--- a/syntax/tree.php
+++ b/syntax/tree.php
@@ -49,7 +49,7 @@ class syntax_plugin_bugzillaint_tree extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Handle matches
 	 */
-	public function handle($match, $state, $pos, &$handler){
+	public function handle($match, $state, $pos, Doku_Handler $handler){
 		$matches = array();
 
 		// found tree
@@ -75,7 +75,7 @@ class syntax_plugin_bugzillaint_tree extends DokuWiki_Syntax_Plugin {
 	 * @param array $data
 	 * @return boolean
 	 */
-	public function render($mode, &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		if ($mode != 'xhtml') return false;
 
 		// render tree


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
